### PR TITLE
Changes test to make them pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.precomp
 /blib/
 /.build/
 _build/

--- a/t/correlation.t
+++ b/t/correlation.t
@@ -9,8 +9,8 @@ use Stats;
     my @z = 1,1,1,1;
 
     is cov(@x,@x), variance(@x), 'Covariance of same values is equal to variance';
-    is corrcoef(@x,@x), 1, 'Correlation coefficient is 1 for same values';
-    is corrcoef(@x,@y), -1, 'Correlation correctly calculated';
+    is-approx corrcoef(@x,@x), 1, 'Correlation coefficient is 1 for same values';
+    is-approx corrcoef(@x,@y), -1, 'Correlation correctly calculated';
     is cov(@x,@z), 0, 'No linear dependency';
     is cov(@y,@z), 0, 'No linear dependency';
     ok corrcoef(@x,@z) ~~ Failure, 'Dies because of 0 standard deviation';


### PR DESCRIPTION
It fails with 2018.04. There might have been some change in the underlying numerical routines.